### PR TITLE
refactor: gon の設定値を Hash に纏める

### DIFF
--- a/app/controllers/growth_curve_sample_controller.rb
+++ b/app/controllers/growth_curve_sample_controller.rb
@@ -1,31 +1,29 @@
 class GrowthCurveSampleController < ApplicationController
+  BORDER_COLOR_RED = 'rgba(255, 0, 0, 1)'
+  BORDER_COLOR_BLUE = 'rgba(54, 162, 235, 1)'
+
   def index
-    # 仮で固定値
-    height = [46, 51, 55, 59, 62, 63, 64, 65.5, 66, 66.5, 71, 69.5]
-    # 12.times.map { (30..70).to_a.sample }
-    # gon.height = height
-    gon.height = 12.times.map { (40..70).to_a.sample }
+    gon_set_values = {
+      # 仮で固定値
+      height: [46, 51, 55, 59, 62, 63, 64, 65.5, 66, 66.5, 71, 69.5],
+      weight: [2.26, 3.445, 4.62, 5, 6.05, 6.64, 7.1, 7.4, 7.5, 7.6, 7.8, 7.5],
+      # 描画色の設定
+      borderRed: BORDER_COLOR_RED,
+      borderBlue: BORDER_COLOR_BLUE
+    }
 
-    # NOTE: chart-js で値の数だけ色指定が必要
-    border_red = 'rgba(255, 0, 0, 1)'
-    gon.borderRed = Array.new(height.size) { border_red }
-
-    # -----------------------------------------
-
-    # 仮で固定値
-    weight = [2.26, 3.445, 4.62, 5, 6.05, 6.64, 7.1, 7.4, 7.5, 7.6, 7.8, 7.5]
-    gon.weight = weight
-
-    # NOTE: chart-js で値の数だけ色指定が必要
-    border_blue = 'rgba(54, 162, 235, 1)'
-    # gon.borderBlue = Array.new(weight.size) { border_blue }
-    gon.borderBlue =
-      generate_border_color_propertiy(generate_size: weight.size, rgba: border_blue)
+    gon_set_values.each do |key, value|
+      set_gon_variable_as(key: key, value: value)
+    end
   end
 
   private
 
   def generate_border_color_propertiy(generate_size:, rgba:)
     Array.new(generate_size) { rgba }
+  end
+
+  def set_gon_variable_as(key:, value:)
+    gon.public_send("#{key}=", value)
   end
 end

--- a/app/controllers/growth_curve_sample_controller.rb
+++ b/app/controllers/growth_curve_sample_controller.rb
@@ -19,10 +19,6 @@ class GrowthCurveSampleController < ApplicationController
 
   private
 
-  def generate_border_color_propertiy(generate_size:, rgba:)
-    Array.new(generate_size) { rgba }
-  end
-
   def set_gon_variable_as(key:, value:)
     gon.public_send("#{key}=", value)
   end

--- a/app/controllers/growth_curve_sample_controller.rb
+++ b/app/controllers/growth_curve_sample_controller.rb
@@ -1,6 +1,6 @@
 class GrowthCurveSampleController < ApplicationController
-  BORDER_COLOR_RED = 'rgba(255, 0, 0, 1)'
-  BORDER_COLOR_BLUE = 'rgba(54, 162, 235, 1)'
+  BORDER_COLOR_RED = 'rgba(255, 0, 0, 1)'.freeze
+  BORDER_COLOR_BLUE = 'rgba(54, 162, 235, 1)'.freeze
 
   def index
     gon_set_values = {


### PR DESCRIPTION
# 概要

gon に対して `public_send` を呼び出すことで、Hash から gon の値設定処理が可能になりました

# 変更点

* 「`gon` での値の設定について」書かれている部分が散らばっていたので、Hash にまとめました
* 数値が用いられている部分、色設定は定数に置き換えて、それを参照します
* 「[chart-js で値の数だけ色指定が必要](https://github.com/msm0046/growth_curve_sample/pull/18/commits/bee6928662b940dc9a690ae93c8ff04f1f02a414#diff-10ca59912486b85f5420d50a6226fca9L19-L23)」の部分は、Array ではなく String で指定することで統一的に色設定ができました

# その他

身長・体重の値については、まだデータベースからの取り出し処理が書けていないようなので、そのまま仮固定での記述を残しました