### PR TITLE
root ページを growth_curve_sample#index に設定

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   get 'growth_curve_sample/index'
+  root to: 'growth_curve_sample#index'
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
# 概要

root ページを `growth_curve_sample#index` に設定します

# 変化

これで、 `http://localhost:3000/growth_curve_sample/index` と打つ必要がなくなり

`http://localhost:3000` だけで、成長記録グラフを描画するページにアクセスできるようになります

# Link

[Rails のルーティング # 3.14 rootを使う - Railsガイド](https://railsguides.jp/routing.html#root%E3%82%92%E4%BD%BF%E3%81%86)