### PR TITLE
データベースから成長記録グラフを描画する

### DIFF
--- a/app/controllers/growth_curve_sample_controller.rb
+++ b/app/controllers/growth_curve_sample_controller.rb
@@ -1,4 +1,7 @@
 class GrowthCurveSampleController < ApplicationController
+  BORDER_COLOR_RED = 'rgba(255, 0, 0, 1)'.freeze
+  BORDER_COLOR_BLUE = 'rgba(54, 162, 235, 1)'.freeze
+
   def index
     growth_records = GrowthRecord.all
 

--- a/app/controllers/growth_curve_sample_controller.rb
+++ b/app/controllers/growth_curve_sample_controller.rb
@@ -1,20 +1,15 @@
 class GrowthCurveSampleController < ApplicationController
   def index
-    # 仮で固定値
-    height = [46, 51, 55, 59, 62, 63, 64, 65.5, 66, 66.5, 71, 69.5]
-    # 12.times.map { (30..70).to_a.sample }
-    # gon.height = height
-    gon.height = 12.times.map { (40..70).to_a.sample }
+    growth_records = GrowthRecord.all
 
-    # NOTE: chart-js で値の数だけ色指定が必要
-    border_red = 'rgba(255, 0, 0, 1)'
-    gon.borderRed = Array.new(height.size) { border_red }
-
-    # -----------------------------------------
-
-    # 仮で固定値
-    weight = [2.26, 3.445, 4.62, 5, 6.05, 6.64, 7.1, 7.4, 7.5, 7.6, 7.8, 7.5]
-    gon.weight = weight
+    gon_set_values = {
+      # 身長・体重のマッピング
+      height: growth_records.map { |attr| attr.height },
+      weight: growth_records.map { |attr| attr.weight },
+      # 描画色の設定
+      borderRed: BORDER_COLOR_RED,
+      borderBlue: BORDER_COLOR_BLUE
+    }
 
     # NOTE: chart-js で値の数だけ色指定が必要
     border_blue = 'rgba(54, 162, 235, 1)'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,25 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+GrowthRecord.destroy_all
+
+# サンプルデータづくりのための可変データ
+growth_record_prams = {
+  height: 20.1,
+  weight: 2.0,
+  age: 0, # NOTE: 年齢は変更対象にしない
+  age_of_the_moon: 0
+}
+
+# GrowthRecord を 12ヶ月分作成
+12.times do |i|
+  # サンプル成長記録なので単純に加算させる
+  growth_record_prams[:height] += 3.0
+  growth_record_prams[:weight] += 0.5
+  growth_record_prams[:age_of_the_moon] += 1
+
+  GrowthRecord.create!(
+    growth_record_prams
+  )
+end


### PR DESCRIPTION
# 概要

データベースから成長記録グラフを描画できるようにする

今回は、読み込み部分を追加

# データについて

サンプルとして `db/seeds.rb` に適当なデータを定義した

`bundle e rails db:seed` コマンドで読み込みができる

# Link

[Active Record マイグレーション # 8 マイグレーションとシードデータ - Railsガイド](https://railsguides.jp/active_record_migrations.html#%E3%83%9E%E3%82%A4%E3%82%B0%E3%83%AC%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E3%81%A8%E3%82%B7%E3%83%BC%E3%83%89%E3%83%87%E3%83%BC%E3%82%BF)