### PR TITLE
refactor: map の冗長な書き方を短縮形に更新

### DIFF
--- a/app/controllers/growth_curve_sample_controller.rb
+++ b/app/controllers/growth_curve_sample_controller.rb
@@ -7,8 +7,8 @@ class GrowthCurveSampleController < ApplicationController
 
     gon_set_values = {
       # 身長・体重のマッピング
-      height: growth_records.map { |attr| attr.height },
-      weight: growth_records.map { |attr| attr.weight },
+      height: growth_records.map(&:height),
+      weight: growth_records.map(&:weight),
       # 描画色の設定
       borderRed: BORDER_COLOR_RED,
       borderBlue: BORDER_COLOR_BLUE


### PR DESCRIPTION
# 概要

当該部分の `map` が短縮形で記述可能なので、そちらに書き換えました