### PR TITLE
Gemfile から Coffee Script を削除

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,8 +20,6 @@ gem 'uglifier', '>= 1.3.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'therubyracer', platforms: :ruby
 
-# Use CoffeeScript for .coffee assets and views
-gem 'coffee-rails', '~> 4.2'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
 gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,13 +61,6 @@ GEM
       railties (> 3.1)
     childprocess (3.0.0)
     coderay (1.1.3)
-    coffee-rails (4.2.2)
-      coffee-script (>= 2.2.0)
-      railties (>= 4.0.0)
-    coffee-script (2.4.1)
-      coffee-script-source
-      execjs
-    coffee-script-source (1.12.2)
     concurrent-ruby (1.1.6)
     crass (1.0.6)
     diff-lcs (1.4.4)
@@ -254,7 +247,6 @@ DEPENDENCIES
   byebug
   capybara (~> 2.13)
   chart-js-rails (~> 0.1.4)
-  coffee-rails (~> 4.2)
   fuubar
   gon (~> 6.2.0)
   guard


### PR DESCRIPTION
# 概要

Gemfile から Coffee Script を削除します

# 詳細

`rails generate ...` コマンドを使用した際に、 Coffee Script ファイルが生成されるのを抑制します

# 理由

Coffee Script 独自の記法を覚えなくても、JavaScript で充分にコードを記述・表現できる