### PR TITLE
成長記録レコード作成時にページ遷移を加える

### DIFF
--- a/app/controllers/growth_curve_sample_controller.rb
+++ b/app/controllers/growth_curve_sample_controller.rb
@@ -27,7 +27,16 @@ class GrowthCurveSampleController < ApplicationController
 
   def create
     @growth_record = GrowthRecord.new(growth_record_params)
-    @growth_record.save # 保存する
+
+    # flash メッセージの設定
+    if @growth_record.save
+      flash[:success] = 'レコードを作成しました!'
+    else
+      flash[:error] = "レコードを作成できませんでした"
+      flash[:error_messages] = @growth_record.errors.messages
+    end
+
+    redirect_to growth_curve_sample_index_path
   end
 
   private

--- a/app/models/growth_record.rb
+++ b/app/models/growth_record.rb
@@ -1,2 +1,3 @@
 class GrowthRecord < ApplicationRecord
+  validates :age_of_the_moon, uniqueness: { scope: :age, message: '年齢と月齢は重複して記録できません'}
 end

--- a/app/views/growth_curve_sample/index.html.erb
+++ b/app/views/growth_curve_sample/index.html.erb
@@ -1,4 +1,21 @@
 <div class="container-fruid mt-5">
+  <% if flash[:success].present? %>
+    <div class="alert alert-success" role="alert">
+      <%= flash[:success] %>
+    </div>
+  <% end %>
+  <% if flash[:error].present? %>
+    <div class="alert alert-danger" role="alert">
+      <%= flash[:error] %>
+      <ul>
+        <% flash[:error_messages].each do |_column, messages| %>
+          <% messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
     <div class="row">
         <div class="col-xs-12 col-xl-8 offset-xl-1">
             <canvas id="myChart" width="250" height="150"></canvas>
@@ -44,7 +61,7 @@
                 <%= f.text_field :weight %>
               </div>
             </div>
-            
+
             <div class="form-group">
               <label class="control-label col-lg-3">身長</label>
               <div class="col-lg-6">


### PR DESCRIPTION
# 概要

成長記録レコード作成時にページ遷移を加える

Close #34 

# 変更

* レコードを作成できる「記録する」ボタンクリック時にページ遷移を実行
* レコード作成成功時にユーザにメッセージを表示
* レコード作成失敗時にユーザにメッセージを表示
* 成長記録作成時に年齢・月齢が重複していないかバリデーションを実行

# イメージ

レコード作成成功:

![レコード作成成功時](https://i.gyazo.com/fcba5bc783b9ba52198e0cb88e7c106d.png)

レコード作成失敗:

![レコード作成失敗時](https://i.gyazo.com/1f653126baab6ee5aa11c654a69667a1.png)