### PR TITLE
年齢スライド制御表示機能を追加

### DIFF
--- a/app/assets/javascripts/growth_curve_sample.js
+++ b/app/assets/javascripts/growth_curve_sample.js
@@ -10,7 +10,7 @@ window.draw_graph = function () {
     // データ
     data: {
       // X軸ラベル
-      labels: [...Array(13).keys()].map(i => { return i + 'ヶ月' }), // 0 〜 12ヶ月
+      labels: gon.xLabels, // n才 mヶ月
       // データ設定
       datasets: [
         {
@@ -62,10 +62,10 @@ window.draw_graph = function () {
             position: "left",
             // 表示設定
             display: true,
-            // 最大値最初値設定
+            // 最大値・最小値設定
             ticks: {
-              min: 40,
-              max: 80,
+              min: gon.minHeight,
+              max: gon.maxHeight,
               stepSize: 5,
               callback: (value, _index, _values) => { return value + 'cm' }
             },
@@ -80,8 +80,8 @@ window.draw_graph = function () {
             display: true,
             // 最大値最初値設定
             ticks: {
-              min: 1,
-              max: 12,
+              min: gon.minWeight,
+              max: gon.maxWeight,
               stepSize: 1,
               callback: (value, _index, _values) => { return value + 'kg' }
             },

--- a/app/helpers/growth_curve_sample_helper.rb
+++ b/app/helpers/growth_curve_sample_helper.rb
@@ -1,2 +1,30 @@
 module GrowthCurveSampleHelper
+  # NOTE: GrowthCurveSampleController にも定数定義あり
+  AGE_SLIDE = 3.freeze
+
+  # 年齢 (n才〜m才) を AGE_SLIDE 分 前後させるためのリンクを生成する
+  # 表示可能なデータ範囲を超えそうになった時、リンクではなくただの文字列を表示させる
+  def age_slide_link(direction:)
+    case direction
+    when :prev
+      if (0..AGE_SLIDE).cover?(@current_max_age)
+        '<'
+      else
+        tag.a('<', href: growth_curve_sample_index_path(current_set_age: @current_max_age.to_i - AGE_SLIDE))
+      end
+    when :next
+      if params[:current_set_age].to_i > @max_age
+        '>'
+      else
+        tag.a('>', href: growth_curve_sample_index_path(current_set_age: @current_max_age.to_i + AGE_SLIDE))
+      end
+    end
+  end
+
+  # 「< n才〜m才 >」の表示とその年齢操作リンクを生成する
+  def age_slider
+    concat(age_slide_link(direction: :prev))
+    concat( "#{@current_min_age}才 〜 #{@current_max_age}才")
+    concat(age_slide_link(direction: :next))
+  end
 end

--- a/app/views/growth_curve_sample/index.html.erb
+++ b/app/views/growth_curve_sample/index.html.erb
@@ -16,6 +16,9 @@
       </ul>
     </div>
   <% end %>
+  <h1 class="text-center">
+    <% age_slider %>
+  </h1>
     <div class="row">
         <div class="col-xs-12 col-xl-8 offset-xl-1">
             <canvas id="myChart" width="250" height="150"></canvas>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,18 +12,24 @@ GrowthRecord.destroy_all
 growth_record_params = {
   height: 20.1,
   weight: 2.0,
-  age: 0, # NOTE: 年齢は変更対象にしない
+  age: 0,
   age_of_the_moon: 0
 }
 
-# GrowthRecord を 12ヶ月分作成
-12.times do |i|
-  # サンプル成長記録なので単純に加算させる
-  growth_record_params[:height] += 3.0
-  growth_record_params[:weight] += 0.5
-  growth_record_params[:age_of_the_moon] += 1
+# 0才から6才までのデータを作成
+6.times do
+  # GrowthRecord を 12ヶ月分作成
+  12.times do
+    GrowthRecord.create!(
+      growth_record_params
+    )
 
-  GrowthRecord.create!(
-    growth_record_params
-  )
+    # サンプル成長記録なので単純に加算させる
+    growth_record_params[:height] += 1.5
+    growth_record_params[:weight] += 0.5
+    growth_record_params[:age_of_the_moon] += 1
+  end
+
+  growth_record_params[:age_of_the_moon] = 0
+  growth_record_params[:age] += 1
 end


### PR DESCRIPTION
Fix #33
Close #37

# 概要

成長記録ページのグラフ描画に機能追加

# 詳細

* 「n才〜m才」の表示を追加、年齢を絞り込み表示できる
* `<`, `>` リンク文字列を追加、年齢区間を移動できる

# イメージ

![年齢区間を移動している様子](https://i.gyazo.com/0360d932cdc082c1906f327a73cf98f1.gif)