### PR TITLE
成長記録編集・削除ページの追加

### DIFF
--- a/app/assets/javascripts/growth_curve_sample.js
+++ b/app/assets/javascripts/growth_curve_sample.js
@@ -160,10 +160,10 @@ class TranscribeEventRegistrar{
       ['.js-growth_record__edit', this._transcribeTableDataToEditModalForm],
       ['.js-growth_record__delete', this._transcribeTableDataToDeleteModalForm]
     ].forEach(([selector, method]) => {
-      Array.from(document.querySelectorAll(selector))
-           .map((elm) => {
-             elm.addEventListener('click', method)
-           });
+      document.querySelectorAll(selector)
+              .forEach((elm) => {
+                elm.addEventListener('click', method)
+              });
     })
   }
 

--- a/app/assets/javascripts/growth_curve_sample.js
+++ b/app/assets/javascripts/growth_curve_sample.js
@@ -95,3 +95,85 @@ window.draw_graph = function () {
     },
   });
 };
+
+// テーブルの <td/> から値を取得することを想定
+// [編集], [削除] ボタンを押した行の値を取得
+function getTableDataElementValue(context, name) {
+  return (
+    context.parentElement
+           .parentElement
+           .querySelector(''.concat('span.js-', name))
+           .innerHTML
+  );
+}
+
+// NOTE: set 系で再利用するので keys の順序は要固定
+function getTableRowValues(context) {
+  keys = ['id', 'height', 'weight', 'age_of_the_moon', 'age'];
+
+  return (
+    keys.map(key => { return getTableDataElementValue(context, key) })
+  );
+}
+
+// [編集] ボタンで表示されるモーダルに値をセット
+function setModalFormElementValue(prefix, name, value) {
+  var target =
+    document.querySelector(''.concat('#growth_record__', prefix, '-', name));
+
+  target.value = value;
+}
+
+// [編集] ボタンを押したテーブル行の値をモーダルに転写
+function transcribeTableDataToEditModalForm() {
+  setModalFormElementValues('edit', getTableRowValues(this))
+}
+
+// [削除] ボタンを押したテーブル行の値をモーダルに転写
+function transcribeTableDataToDeleteModalForm() {
+  setModalFormElementValues('delete', getTableRowValues(this))
+}
+
+// テーブルの行から取得した値をモーダルに転写
+function setModalFormElementValues(prefix, targetValues) {
+  [id, height, weight, ageOfTheMoon, age] = targetValues;
+
+  setModalFormElementValue(prefix, 'id', id);
+  setModalFormElementValue(prefix, 'height', height);
+  setModalFormElementValue(prefix, 'weight', weight);
+  setModalFormElementValue(prefix, 'age_of_the_moon', ageOfTheMoon);
+  setModalFormElementValue(prefix, 'age', age);
+}
+
+//
+// onClick イベント設定
+// [編集] ボタンにモーダルへの値の転写機能を付与
+//
+function setModalFromFormValuesOnClick(element) {
+  element.addEventListener('click', transcribeTableDataToEditModalForm)
+}
+
+//
+// onClick イベント設定
+// [削除] ボタンにモーダルへの値の転写機能を付与
+//
+function setDeleteModalFromValuesOnClick(element) {
+  element.addEventListener('click', transcribeTableDataToDeleteModalForm)
+}
+
+// ボタンクリックで data 属性値にある要素を対象に submit を実行
+// data 属性値は <form/> の ID 指定を期待 (#some-form-name)
+function formSubmit(context) {
+  document.querySelector(context.dataset.submitFormTarget).submit();
+}
+
+// イベント処理の初期化
+document.addEventListener('turbolinks:load', function() {
+  // [編集] ボタンを押したときのモーダルへの値転写機能
+  Array.from(document.querySelectorAll('.js-growth_record__edit'))
+       .map((elm) => { setModalFromFormValuesOnClick(elm); });
+
+  // [削除] ボタンを押したときのモーダルへの値転写機能
+  Array.from(document.querySelectorAll('.js-growth_record__delete'))
+       .map((elm) => { setDeleteModalFromValuesOnClick(elm); });
+});

--- a/app/assets/javascripts/growth_curve_sample.js
+++ b/app/assets/javascripts/growth_curve_sample.js
@@ -149,7 +149,7 @@ function setModalFormElementValues(prefix, targetValues) {
 // onClick イベント設定
 // [編集] ボタンにモーダルへの値の転写機能を付与
 //
-function setModalFromFormValuesOnClick(element) {
+function setEditModalFromFormValuesOnClick(element) {
   element.addEventListener('click', transcribeTableDataToEditModalForm)
 }
 
@@ -171,7 +171,7 @@ function formSubmit(context) {
 document.addEventListener('turbolinks:load', function() {
   // [編集] ボタンを押したときのモーダルへの値転写機能
   Array.from(document.querySelectorAll('.js-growth_record__edit'))
-       .map((elm) => { setModalFromFormValuesOnClick(elm); });
+       .map((elm) => { setEditModalFromFormValuesOnClick(elm); });
 
   // [削除] ボタンを押したときのモーダルへの値転写機能
   Array.from(document.querySelectorAll('.js-growth_record__delete'))

--- a/app/assets/javascripts/growth_curve_sample.js
+++ b/app/assets/javascripts/growth_curve_sample.js
@@ -116,7 +116,7 @@ function getTableRowValues(context) {
   );
 }
 
-// [編集] ボタンで表示されるモーダルに値をセット
+// [編集], [削除] ボタンで表示されるモーダルに値をセット
 function setModalFormElementValue(prefix, name, value) {
   var target =
     document.querySelector(''.concat('#growth_record__', prefix, '-', name));

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -78,7 +78,11 @@
 }
 
 #growth-record__edit thead tr th {
-  background: #FEFEFE;
+  position: sticky;
+  top: 47px;
+}
+
+.sticky {
   position: sticky;
   top: 0;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -71,3 +71,14 @@
 }
 #growth_record_height {
 }
+
+#growth_record__edit {
+  position: relative;
+  border-collapse: collapse;
+}
+
+#growth-record__edit thead tr th {
+  background: #FEFEFE;
+  position: sticky;
+  top: 0;
+}

--- a/app/controllers/growth_curve_sample_controller.rb
+++ b/app/controllers/growth_curve_sample_controller.rb
@@ -42,8 +42,6 @@ class GrowthCurveSampleController < ApplicationController
     @growth_record = GrowthRecord.new
   end
 
-  # TODO: CRUD の残りの部分を作成
-
   def create
     @growth_record = GrowthRecord.new(growth_record_params)
 
@@ -56,6 +54,30 @@ class GrowthCurveSampleController < ApplicationController
     end
 
     redirect_to growth_curve_sample_index_path
+  end
+
+  def edit
+    @growth_records =
+      GrowthRecord.all
+                  .reorder(:age)
+                  .order(:age_of_the_moon)
+  end
+
+  def update
+    @growth_record = GrowthRecord.find(params[:id])
+
+    if @growth_record.update(growth_record_params)
+      redirect_to growth_curve_sample_edit_path
+    else
+      render growth_curve_sample_edit_path
+    end
+  end
+
+  def destroy
+    @growth_record = GrowthRecord.find(params[:id])
+    @growth_record.destroy
+
+    redirect_to growth_curve_sample_edit_path
   end
 
   private

--- a/app/helpers/growth_curve_sample_helper.rb
+++ b/app/helpers/growth_curve_sample_helper.rb
@@ -27,4 +27,24 @@ module GrowthCurveSampleHelper
     concat( "#{@current_min_age}才 〜 #{@current_max_age}才")
     concat(age_slide_link(direction: :next))
   end
+
+  # 年齢別にグループ分けをした growth_records を生成
+  # { n才 => [a, b, c, ...], m才 => [w, x, y, ...]... }
+  # <table/> データの生成に利用
+  def grouped_by_age(growth_records)
+    age_range =
+      (growth_records.first.age..
+       growth_records.last.age).to_a
+
+    age_group = {}
+
+    # キー値を初期化
+    age_range.each { |age| age_group.update(age.to_s => []) }
+
+    growth_records.each do |growth_record|
+      age_group[growth_record.age.to_s] << growth_record
+    end
+
+    age_group
+  end
 end

--- a/app/views/growth_curve_sample/edit.html.erb
+++ b/app/views/growth_curve_sample/edit.html.erb
@@ -1,0 +1,146 @@
+<div class="container">
+  <div class="row">
+    <h1 class="sticky">成長記録 編集</h1>
+  </div>
+  <div class="row">
+    <table id="growth-record__edit" class="table table-striped">
+      <% grouped_by_age(@growth_records).each do |key, values| %>
+        <thead>
+          <tr>
+            <th><%= "#{key}才" %></th>
+            <th class="text-center">身長</th>
+            <th class="text-center">体重</th>
+            <th class="text-right">操作</th>
+          </tr>
+          </th>
+          <tbody>
+            <% values.each do |growth_record| %>
+              <tr>
+                <td
+                  class="text-right align-middle js-age_of_the_moon"
+                  title="<%= "#{growth_record.age}才#{growth_record.age_of_the_moon}ヶ月"%>">
+                  <span class="js-id" style="display:none;"><%=growth_record.id %></span>
+                  <span class="js-age" style="display:none;"><%= growth_record.age %></span>
+                  <span class="js-age_of_the_moon"><%= growth_record.age_of_the_moon %></span>
+                  ヶ月
+                </td>
+                <td class="text-right align-middle js-height">
+                  <span class="js-height"><%= growth_record.height %></span>
+                  cm
+                </td>
+                <td class="text-right align-middle js-weight">
+                  <span class="js-weight"><%= growth_record.weight %></span>
+                  kg
+                </td>
+                <td class="text-right align-middle">
+                  <button
+                    data-toggle="modal"
+                    data-target="#growth-record-edit__edit_modal"
+                    class="btn btn-secondary js-growth_record__edit">
+                    編集
+                  </button>
+                  <button
+                    data-toggle="modal"
+                    data-target="#growth-record-edit__delete_modal"
+                    class="btn btn-danger js-growth_record__delete">
+                    削除
+                  </button>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        <% end %>
+    </table>
+  </div>
+</div>
+
+<div id="growth-record-edit__edit_modal" class="modal" tabindex="-1">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">記録の編集</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <%= form_tag(growth_curve_sample_update_path, id: 'growth_record__edit-form', class: 'form') do -%>
+          <%= text_field_tag(:id, '', id: 'growth_record__edit-id', type: 'hidden') %>
+            <div class="form-group">
+              <label class="control-label col-lg-3">月齢</label>
+              <div class="col-lg-6">
+                <%= text_field_tag('growth_record[age]', '', id: 'growth_record__edit-age') %><input id="unit-display__age" type="text" disabled="true" value="才">
+                <%= text_field_tag('growth_record[age_of_the_moon]', '', id: 'growth_record__edit-age_of_the_moon') %><input id="unit-display__age_of_the_moon" type="text" disabled="true" value="ヶ月">
+              </div>
+            </div>
+
+            <div class="form-group">
+              <label class="control-label col-lg-3">体重</label>
+              <div class="col-lg-6">
+                <%= text_field_tag('growth_record[weight]', '', id: 'growth_record__edit-weight') %>
+                <input id="unit-display__weight" type="text" disabled="true" value="kg">
+              </div>
+            </div>
+
+            <div class="form-group">
+              <label class="control-label col-lg-3">身長</label>
+              <div class="col-lg-6">
+                <%= text_field_tag('growth_record[height]', '', id: 'growth_record__edit-height') %>
+                <input id="unit-display__height" type="text" disabled="true" value="cm">
+              </div>
+            </div>
+        <% end %>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-primary" data-submit-form-target="#growth_record__edit-form" onclick="formSubmit(this)">更新する</button>
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">閉じる</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div id="growth-record-edit__delete_modal" class="modal" tabindex="-1">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">記録の削除</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <p>この記録を削除しますか？</p>
+        <%= form_tag(growth_curve_sample_destroy_path, id: 'growth_record__delete-form', class: 'form') do -%>
+          <%= text_field_tag(:id, '', id: 'growth_record__delete-id', type: 'hidden') %>
+            <div class="form-group">
+              <label class="control-label col-lg-3">月齢</label>
+              <div class="col-lg-6">
+                <%= text_field_tag('growth_record[age]', '', id: 'growth_record__delete-age') %><input id="unit-display__age" type="text" disabled="true" value="才">
+                <%= text_field_tag('growth_record[age_of_the_moon]', '', id: 'growth_record__delete-age_of_the_moon') %><input id="unit-display__age_of_the_moon" type="text" disabled="true" value="ヶ月">
+              </div>
+            </div>
+
+            <div class="form-group">
+              <label class="control-label col-lg-3">体重</label>
+              <div class="col-lg-6">
+                <%= text_field_tag('growth_record[weight]', '', id: 'growth_record__delete-weight') %>
+                <input id="unit-display__weight" type="text" disabled="true" value="kg">
+              </div>
+            </div>
+
+            <div class="form-group">
+              <label class="control-label col-lg-3">身長</label>
+              <div class="col-lg-6">
+                <%= text_field_tag('growth_record[height]', '', id: 'growth_record__delete-height') %>
+                <input id="unit-display__height" type="text" disabled="true" value="cm">
+              </div>
+            </div>
+        <% end %>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-danger" data-submit-form-target="#growth_record__delete-form" onclick="formSubmit(this)">削除する</button>
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">閉じる</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/growth_curve_sample/edit.html.erb
+++ b/app/views/growth_curve_sample/edit.html.erb
@@ -1,16 +1,14 @@
 <div class="container">
   <div class="row">
-    <h1 class="sticky">成長記録 編集</h1>
-  </div>
-  <div class="row">
+    <h1 class="sticky w-100 bg-white">成長記録 編集</h1>
     <table id="growth-record__edit" class="table table-striped">
       <% grouped_by_age(@growth_records).each do |key, values| %>
         <thead>
           <tr>
-            <th><%= "#{key}才" %></th>
-            <th class="text-center">身長</th>
-            <th class="text-center">体重</th>
-            <th class="text-right">操作</th>
+            <th class="bg-white"><%= "#{key}才" %></th>
+            <th class="bg-white text-center">身長</th>
+            <th class="bg-white text-center">体重</th>
+            <th class="bg-white text-right">操作</th>
           </tr>
           </th>
           <tbody>

--- a/app/views/growth_curve_sample/index.html.erb
+++ b/app/views/growth_curve_sample/index.html.erb
@@ -29,6 +29,9 @@
           <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#growth-record-modal">
             記録する
           </button>
+          <a href="<%= growth_curve_sample_edit_path %>">
+            <button type="button" class="btn btn-secondary">編集する</button>
+          </a>
         </div>
     </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,10 @@
 Rails.application.routes.draw do
   resources :users
   get 'growth_curve_sample/index'
+  get 'growth_curve_sample/edit'
   post 'growth_curve_sample/destroy'
   post 'growth_curve_sample/create'
+  post 'growth_curve_sample/update'
   root to: 'growth_curve_sample#index'
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html


### PR DESCRIPTION
Close #39
Close #40 

# 概要

成長記録の編集・削除ページを追加します

# 詳細

[編集], [削除] ボタンはモーダルを表示して、レコードの更新や削除ができます

# イメージ

スクロール時、ページ中の `<h1/>`, `<th/>` のスクロールを上部に固定

![スクロール時の sticky 化](https://i.gyazo.com/99e931311a6cab7185dc328f36cf415e.gif)

[編集], [削除] ボタンクリックでモーダルを表示

![モーダル表示](https://i.gyazo.com/b8746061cbfba194822c006a7ece618c.gif)