### PR TITLE
成長記録 グラフ再描画 修正

### DIFF
--- a/app/helpers/growth_curve_sample_helper.rb
+++ b/app/helpers/growth_curve_sample_helper.rb
@@ -24,8 +24,10 @@ module GrowthCurveSampleHelper
 
   # 「< n才〜m才 >」の表示とその年齢操作リンクを生成する
   def age_slider
-    concat(age_slide_link(direction: :prev))
-    concat( "#{@current_min_age}才 〜 #{@current_max_age}才")
-    concat(age_slide_link(direction: :next))
+    [
+      age_slide_link(direction: :prev),
+       "#{@current_min_age}才 〜 #{@current_max_age}才",
+      age_slide_link(direction: :next)
+    ].each(&method(:concat))
   end
 end

--- a/app/helpers/growth_curve_sample_helper.rb
+++ b/app/helpers/growth_curve_sample_helper.rb
@@ -4,19 +4,20 @@ module GrowthCurveSampleHelper
 
   # 年齢 (n才〜m才) を AGE_SLIDE 分 前後させるためのリンクを生成する
   # 表示可能なデータ範囲を超えそうになった時、リンクではなくただの文字列を表示させる
+  # NOTE: グラフの再描画時、キャッシュから旧い値が採用されてしまうため、リンク生成時に turbolinks を一時的に off にしている
   def age_slide_link(direction:)
     case direction
     when :prev
       if (0..AGE_SLIDE).cover?(@current_max_age)
         '<'
       else
-        tag.a('<', href: growth_curve_sample_index_path(current_set_age: @current_max_age.to_i - AGE_SLIDE))
+        tag.a('<', href: growth_curve_sample_index_path(current_set_age: @current_max_age.to_i - AGE_SLIDE), data: { turbolinks: false })
       end
     when :next
       if params[:current_set_age].to_i > @max_age
         '>'
       else
-        tag.a('>', href: growth_curve_sample_index_path(current_set_age: @current_max_age.to_i + AGE_SLIDE))
+        tag.a('>', href: growth_curve_sample_index_path(current_set_age: @current_max_age.to_i + AGE_SLIDE), data: { turbolinks: false })
       end
     end
   end


### PR DESCRIPTION
# 概要

「グラフの値が再描画されない」のを修正

# 変更箇所

* `age_slider` 関連箇所 (`app/helpers/growth_curve_sample_helper.rb`)

# 詳細

一見、`age_slider` の年齢移動リンク クリック時、連動してグラフの描画が更新されているように見える

実際は、何度かリンクをクリックしてページ移動した際、グラフの描画が更新されない

# 対策・対応

turbolinks のキャッシュ機構を一時的に無効化することで
常に最新の値を描画できるようにした

(`data-turbolinks="false"` の付与)

# Link

* [turbolinks/turbolinks: Turbolinks makes navigating your web application faster # Disabling Turbolinks on Specific Links - GitHub](https://github.com/turbolinks/turbolinks#disabling-turbolinks-on-specific-links)